### PR TITLE
Speed up legal moves checking in engine

### DIFF
--- a/Chess.hpp
+++ b/Chess.hpp
@@ -34,6 +34,7 @@ private:
    std::vector<std::shared_ptr<ChessMove>> getRookMoves(int row, int column);
    std::vector<std::shared_ptr<ChessMove>> getKingMoves(int row, int column);
    std::vector<std::shared_ptr<ChessMove>> getQueenMoves(int row, int column);
+   bool isMoveLegal(std::shared_ptr<ChessMove> move);
    bool isUnderCheck(int color);
    bool canPlayerCastle(int color, int side);
    void handleCastling(bool kingside);

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PROG = game-engine
 CC = g++
-CPPFLAGS = -O2 -std=c++17 -Wall -g -fsanitize=address
-LDFLAGS=-lm -fsanitize=address -g
+CPPFLAGS = -O2 -std=c++17 -Wall -g
+LDFLAGS=-lm -g
 OBJS = main.o Move.o ChessMove.o Game.o ChessPiece.o Chess.o Node.o MCTS.o
 
 $(PROG) : $(OBJS)

--- a/main.cpp
+++ b/main.cpp
@@ -5,52 +5,59 @@ int main()
 {
    srand(time(NULL));
    std::shared_ptr<Game> real_game = std::make_shared<Chess>();
+
    std::shared_ptr<Game> game = std::make_shared<Chess>();
-   
+
    MCTS mcts(game);
 
    auto moves = real_game->getPossibleMoves();
 
    int player = 0;
 
-   while(real_game->gameStatus(moves) == GameStatus::IN_PROGRESS)
+   while (real_game->gameStatus(moves) == GameStatus::IN_PROGRESS)
    {
       std::shared_ptr<Move> move = nullptr;
 
-      if(player == 0){
+      if (player == 0)
+      {
          mcts.run();
          auto best_move = mcts.getBestMove();
          move = best_move.first;
-      } else {
+      }
+      else
+      {
          move = real_game->getPossibleMoves()[rand() % real_game->getPossibleMoves().size()];
       }
 
       mcts.doMove(move);
       real_game->simulateMove(move);
-      std::cout << real_game->printBoard() << std::endl;
-      moves = real_game->getPossibleMoves();
       player = 1 - player;
       real_game->setCurrentPlayer(player);
+      std::cout << real_game->printBoard() << std::endl;
+      moves = real_game->getPossibleMoves();
    }
 
    switch (real_game->gameStatus(moves))
    {
-      case GameStatus::DRAW:
-         std::cout << "Draw" << std::endl;
-         break;
-      case GameStatus::STALE_MATE:
-         std::cout << "Stalemate" << std::endl;
-         break;
-      case GameStatus::CHECK_MATE:
-         std::cout << "Checkmate, ";
-         if(player) {
-            std::cout << "Black wins" << std::endl;
-         } else {
-            std::cout << "White wins" << std::endl;
-         }
-         break;
-      default:
-         break;
+   case GameStatus::DRAW:
+      std::cout << "Draw" << std::endl;
+      break;
+   case GameStatus::STALE_MATE:
+      std::cout << "Stalemate" << std::endl;
+      break;
+   case GameStatus::CHECK_MATE:
+      std::cout << "Checkmate, ";
+      if (!player)
+      {
+         std::cout << "Black wins" << std::endl;
+      }
+      else
+      {
+         std::cout << "White wins" << std::endl;
+      }
+      break;
+   default:
+      break;
    }
 
    return 0;


### PR DESCRIPTION
Now the engine doesn't have to copy the game object to check if the move is legal, which significantly decreases simulation time.