### PR TITLE
Fixes in MCTS

### DIFF
--- a/MCTS.cpp
+++ b/MCTS.cpp
@@ -8,11 +8,11 @@ MCTS::MCTS(std::shared_ptr<Game> game)
 void MCTS::run()
 {
    int player = this->getRoot()->getGame()->getCurrentPlayer();
-   for (int i = 0; i < 10; i++) // placeholder
+   for (int i = 0; i < 100; i++) // placeholder
    {
       std::shared_ptr<Node> node(this->treePolicy(this->getRoot()));
 
-      int result = this->simulate(node);
+      double result = this->simulate(node);
 
       backpropagate(node, player, result);
    }
@@ -113,7 +113,7 @@ std::shared_ptr<Node> MCTS::expand(std::shared_ptr<Node> node)
    gameCopy->simulateMove(node->getPossibleMoves()[node->getLastExpanded()]);
    gameCopy->setCurrentPlayer(1 - gameCopy->getCurrentPlayer());
 
-   auto child = std::make_shared<Node>(gameCopy->getPossibleMoves(), gameCopy);
+   auto child = std::make_shared<Node>(gameCopy->getPossibleMoves(), gameCopy, node);
    node->getChildren()[node->getLastExpanded()] = child;
    if (child->getGame()->gameStatus(gameCopy->getPossibleMoves()) != -1)
       child->setTerminal(true);

--- a/Node.cpp
+++ b/Node.cpp
@@ -69,5 +69,5 @@ std::shared_ptr<Game> Node::getGame()
 
 std::shared_ptr<Node> Node::getParent()
 {
-   return this->parent;
+   return this->parent.lock();
 }

--- a/Node.hpp
+++ b/Node.hpp
@@ -11,7 +11,7 @@ private:
    int lastExpanded;
    bool terminal;
    std::shared_ptr<Game> game;
-   std::shared_ptr<Node> parent;
+   std::weak_ptr<Node> parent; // This can't be a shared pointer
    std::vector<std::shared_ptr<Move>> possibleMoves;
    std::unordered_map<int, std::shared_ptr<Node>> children;
 

--- a/main.cpp
+++ b/main.cpp
@@ -21,6 +21,9 @@ int main()
       if (player == 0)
       {
          mcts.run();
+         double w = mcts.getRoot()->getScore(player);
+         double n = mcts.getRoot()->getSimulations();
+         std::cout << "board value: " << w / n << std::endl;
          auto best_move = mcts.getBestMove();
          move = best_move.first;
       }


### PR DESCRIPTION
Fixed a bug where parent was not set during expansion.

Changed a pointer to parent in Node to weak_ptr, so that the rest of the tree is correctly deleted when the root is swapped in doMove. 